### PR TITLE
Slight Code Cleaning

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -4,7 +4,7 @@ namespace humhub\modules\hhcf;
 
 use Yii;
 use yii\helpers\Url;
-use yii\base\Object
+use yii\base\Object;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\models\User;
 use humhub\modules\space\modules\manage\widgets;

--- a/Events.php
+++ b/Events.php
@@ -1,17 +1,17 @@
 <?php
 
 namespace humhub\modules\hhcf;
+
+use Yii;
+use yii\helpers\Url;
+use yii\base\Object
 use humhub\modules\space\models\Space;
 use humhub\modules\user\models\User;
 use humhub\modules\space\modules\manage\widgets;
-use Yii;
-use yii\helpers\Url;
 
-class Events extends \yii\base\Object
+class Events extends Object
 {
 
-    
-    
     public static function onSpaceAdminInit($event)
     {
         if ($event->sender->space !== null && $event->sender->space->isModuleEnabled('hhcf') && $event->sender->space->isMember()) {

--- a/Module.php
+++ b/Module.php
@@ -1,16 +1,17 @@
 <?php
 
 namespace humhub\modules\hhcf;
+
 use Yii;
+use yii\helpers\Url;
 use humhub\modules\space\models\Space;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\content\components\ContentContainerModule;
-use yii\helpers\Url;
 
 class Module extends ContentContainerModule
 {
 
-/**
+    /**
      * @inheritdoc
      */
     public function getContentContainerTypes()
@@ -23,7 +24,7 @@ class Module extends ContentContainerModule
     public function getConfigUrl()
     {
         return Url::to([
-                    '/hhcf/config'
+            '/hhcf/config'
         ]);
     }
 

--- a/assets/Assets.php
+++ b/assets/Assets.php
@@ -2,24 +2,26 @@
 
 namespace humhub\modules\hhcf\assets;
 
+use Yii;
+use yii\web\View;
 use yii\web\AssetBundle;
 
-class Assets extends AssetBundle{
+class Assets extends AssetBundle
+{
     public $publishOptions = [
         'forceCopy' => true,
         'linkAssets' =>true
     ];
-    
+
     public $css = [
         'css/hhcf.css',
     ];
-    
+
     public $jsOptions = [
-        'position' => \yii\web\View::POS_BEGIN
+        'position' => View::POS_BEGIN
     ];
-    
-    public $js = [
-    ];
+
+    public $js = [];
 
     public function init()
     {

--- a/config.php
+++ b/config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Yii;
 use humhub\modules\content\widgets\WallEntryLinks;
 use humhub\commands\IntegrityController;
 use humhub\modules\space\widgets\Menu;

--- a/controllers/ConfigController.php
+++ b/controllers/ConfigController.php
@@ -1,23 +1,13 @@
 <?php
 
-/**
- * @link https://www.humhub.org/
- * @copyright Copyright (c) 2015 HumHub GmbH & Co. KG
- * @license https://www.humhub.com/licences
- */
-
 namespace humhub\modules\hhcf\controllers;
 
 use Yii;
-use humhub\modules\cfiles\models\ConfigureForm;
+// use humhub\modules\hhcf\models\ConfigureForm; // Markded out till directory is made!
 use humhub\models\Setting;
 
 /**
  * ConfigController handles the configuration requests.
- *
- * @package humhub.modules.cfiles.controllers
- * @since 1.0
- * @author Sebastian Stumpf
  */
 class ConfigController extends \humhub\modules\admin\components\Controller
 {
@@ -27,11 +17,8 @@ class ConfigController extends \humhub\modules\admin\components\Controller
      */
     public function actionIndex()
     {
-        
 
         return $this->render('index');
     }
 
 }
-
-

--- a/controllers/EditController.php
+++ b/controllers/EditController.php
@@ -1,17 +1,10 @@
 <?php
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 namespace humhub\modules\hhcf\controllers;
 
 use Yii;
-use humhub\modules\cfiles\models\ConfigureForm;
+// use humhub\modules\hhcf\models\ConfigureForm; // Markded out till directory is made!
 use humhub\models\Setting;
-
 
 class EditController extends \humhub\modules\admin\components\Controller
 {
@@ -21,7 +14,6 @@ class EditController extends \humhub\modules\admin\components\Controller
      */
     public function actionIndex()
     {
-        
 
         return $this->render('index');
     }

--- a/controllers/SpaceController.php
+++ b/controllers/SpaceController.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace humhub\modules\hhcf\controllers;
+
 use Yii;
 use humhub\modules\space\modules\manage\components\Controller;
 use humhub\modules\space\modules\manage\models\DeleteForm;

--- a/resources/css/hhcf.css
+++ b/resources/css/hhcf.css
@@ -1,13 +1,3 @@
-/*
-To change this license header, choose License Headers in Project Properties.
-To change this template file, choose Tools | Templates
-and open the template in the editor.
-*/
-/* 
-    Created on : Sep 29, 2017, 6:49:22 PM
-    Author     : marat
-*/
-
 .template_select{
     height: 100px;
     width: 150px;
@@ -15,7 +5,6 @@ and open the template in the editor.
     border:1px solid red;
     padding: 10px;
 }
-
 
 .template_add{
     height: 100px;

--- a/views/config/index.php
+++ b/views/config/index.php
@@ -6,8 +6,8 @@ use yii\helpers\Html;
 
 <div class="panel panel-default">
 
-    <div class="panel-heading"><?php echo Yii::t('HhcfModule.Base', '<strong>HHCF</strong>  module configuration'); ?></div>
-    <div class="control-label">&nbsp;&nbsp;<?php echo Yii::t('HhcfModule.Base', 'Templates'); ?>:</div>
+    <div class="panel-heading"><?= Yii::t('HhcfModule.Base', '<strong>HHCF</strong>  module configuration'); ?></div>
+    <div class="control-label">&nbsp;&nbsp;<?= Yii::t('HhcfModule.Base', 'Templates'); ?>:</div>
     <div class="panel-body">
 
     </div>

--- a/views/edit/index.php
+++ b/views/edit/index.php
@@ -1,16 +1,11 @@
 <?php
 
-/* 
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 ?>
 
 <div class="panel panel-default">
 
-    <div class="panel-heading"><?php echo Yii::t('HhcfModule.Base', '<strong>HHCF</strong>  module configuration'); ?></div>
-    <div class="control-label">&nbsp;&nbsp;<?php echo Yii::t('HhcfModule.Space', '<strong>Edit template</strong>'); ?>:</div>
+    <div class="panel-heading"><?= Yii::t('HhcfModule.Base', '<strong>HHCF</strong>  module configuration'); ?></div>
+    <div class="control-label">&nbsp;&nbsp;<?= Yii::t('HhcfModule.Space', '<strong>Edit template</strong>'); ?>:</div>
     <div class="panel-body">
 
     </div>

--- a/views/main/index.php
+++ b/views/main/index.php
@@ -5,12 +5,10 @@
 
             <div class="panel-heading">Headline</div>
 
-
             <div class="panel-body">
 
                 <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
             </div>
-
 
         </div>
 

--- a/views/space/index.php
+++ b/views/space/index.php
@@ -1,17 +1,16 @@
 <?php
 
-
-\humhub\modules\hhcf\assets\Assets::register($this);
 use yii\bootstrap\ActiveForm;
 use yii\helpers\Html;
 use humhub\modules\space\modules\manage\widgets\DefaultMenu;
 
+\humhub\modules\hhcf\assets\Assets::register($this);
 ?>
 
 <div class="panel panel-default">
     <div>
         <div class="panel-heading">
-            <?php echo Yii::t('SpaceModule.views_settings', '<strong>Space</strong> settings'); ?>
+            <?= Yii::t('SpaceModule.views_settings', '<strong>Space</strong> settings'); ?>
         </div>
     </div>
 
@@ -19,11 +18,11 @@ use humhub\modules\space\modules\manage\widgets\DefaultMenu;
     <div class="panel-body">
  
         <hr>
-        <?php echo Yii::t('HhcfModule.Space', '<strong>Select template</strong>'); ?>
+        <?= Yii::t('HhcfModule.Space', '<strong>Select template</strong>'); ?>
         <hr>
         <div class="template_box">
             <div class="template_select">-</div>
-            <div class="template_add"><a href=""><?php echo Yii::t('HhcfModule.Space', '<strong>Add template</strong>'); ?></a></div>
+            <div class="template_add"><a href=""><?= Yii::t('HhcfModule.Space', '<strong>Add template</strong>'); ?></a></div>
         </div>
 
     </div>

--- a/widgets/AddCFToSpace.php
+++ b/widgets/AddCFToSpace.php
@@ -2,23 +2,15 @@
 
 namespace humhub\modules\hhcf\widgets;
 
+use Yii;
 use humhub\components\Widget;
 
-/**
- * PollWallEntryWidget is used to display a poll inside the stream.
- *
- * This Widget will used by the Poll Model in Method getWallOut().
- *
- * @package humhub.modules.polls.widgets
- * @since 0.5
- * @author Luke
- */
 class AddfieldToSpace extends Widget
 {
-    
+
     public $name;
     public $showTitle;
-    
+
     public function run()
     {
         return $this->render('AddCFToSpace');

--- a/widgets/views/AddCFToSpace.php
+++ b/widgets/views/AddCFToSpace.php
@@ -1,4 +1,3 @@
 <?php
 
 echo "ewdewd";
-


### PR DESCRIPTION
As I've said before, I'd recommend using `yii\base\BaseObject` over `yii\base\Object` soon.

As for changing and marking out `use humhub\modules\cfiles\models\ConfigureForm;`, I believe piggybacking the cfiles module wouldn't be the best option, creating your own `/models/ConfigureForm.php` would be needed in the long run of things, once done you should uncomment this out for the two controllers this was done in.